### PR TITLE
remove reference to auto logging in parents on subsequent calls

### DIFF
--- a/signup.md
+++ b/signup.md
@@ -45,8 +45,7 @@ not safely sent through a URL.
 
 Note: This endpoint can safely be used multiple times for a parent. If the
 parent has already signed up, it will not create another, but rather forward
-them safely in to the site while authenticating them as their original Bark
-account.
+them safely to the site where they can log in.
 
 If there is an error, an error with the following format will be returned:
 


### PR DESCRIPTION
This is part of the following issue https://github.com/Bark-us/bark-www/issues/3314 and simply changes the documentation to match the new behavior